### PR TITLE
Changing the master/slave words

### DIFF
--- a/ICM-20948_0.py
+++ b/ICM-20948_0.py
@@ -65,10 +65,10 @@ class ICM_20948_Base:
 	# Bits DMP_RST
 	# Bits SRAM_RST
 	# Bits I2C_MST_RST
-	# 1 - Reset I2C Master module. Reset is asynchronous. This bit auto clears after one
+	# 1 - Reset I2C Main module. Reset is asynchronous. This bit auto clears after one
 	#           clock cycle of the internal 20 MHz clock.
-	#           NOTE: This bit should only be set when the I2C master has hung. If this bit is set during an active
-	#           I2C master transaction, the I2C slave will hang, which will require the host to reset the slave. 
+	#           NOTE: This bit should only be set when the I2C main has hung. If this bit is set during an active
+	#           I2C main transaction, the I2C subordinate will hang, which will require the host to reset the subordinate. 
 	
 	# Bits reserved_0
 	# Register LP_CONFIG
@@ -84,9 +84,9 @@ class ICM_20948_Base:
 	
 	# Bits reserved_0
 	# Bits I2C_MST_CYCLE
-	# 1 - Operate I2C master in duty cycled mode. ODR is determined by
+	# 1 - Operate I2C main in duty cycled mode. ODR is determined by
 	#           I2C_MST_ODR_CONFIG register.
-	#           0 - Disable I2C master duty cycled mode. 
+	#           0 - Disable I2C main duty cycled mode. 
 	
 	# Bits ACCEL_CYCLE
 	# 1 - Operate ACCEL in duty cycled mode. ODR is determined by ACCEL_SMPLRT_DIV
@@ -201,12 +201,12 @@ class ICM_20948_Base:
 	# Bits FSYNC_INT_MODE_EN
 	# 1 - This enables the FSYNC pin to be used as an interrupt. A transition to the active
 	#           level described by the ACTL_FSYNC bit will cause an interrupt. The status of the
-	#           interrupt is read in the I2C Master Status register PASS_THROUGH bit.
+	#           interrupt is read in the I2C Main Status register PASS_THROUGH bit.
 	#           0 - This disables the FSYNC pin from causing an interrupt. 
 	
 	# Bits BYPASS_EN
 	# When asserted, the I2C_MASTER interface pins (ES_CL and ES_DA) will go into
-	#           ‘bypass mode’ when the I2C master interface is disabled. 
+	#           ‘bypass mode’ when the I2C main interface is disabled. 
 	
 	# Bits reserved_0
 	# Register INT_ENABLE
@@ -239,7 +239,7 @@ class ICM_20948_Base:
 	#           0 - Function is disabled. 
 	
 	# Bits I2C_MST_INT_EN
-	# 1 - Enable I2C master interrupt to propagate to interrupt pin 1.
+	# 1 - Enable I2C main interrupt to propagate to interrupt pin 1.
 	#           0 - Function is disabled. 
 	
 	# Register INT_ENABLE_1
@@ -309,32 +309,32 @@ class ICM_20948_Base:
 	#           status bits in this register. 
 	
 	# Bits I2C_SLV4_DONE
-	# Asserted when I2C slave 4’s transfer is complete, will cause an interrupt if bit
+	# Asserted when I2C subordinate 4’s transfer is complete, will cause an interrupt if bit
 	#           I2C_MST_INT_EN in the INT_ENABLE register is asserted, and if the
 	#           SLV4_DONE_INT_EN bit is asserted in the I2C_SLV4_CTRL register. 
 	
 	# Bits I2C_LOST_ARB
-	# Asserted when I2C slave loses arbitration of the I2C bus, will cause an interrupt if bit
+	# Asserted when I2C subordinate loses arbitration of the I2C bus, will cause an interrupt if bit
 	#           I2C_MST_INT_EN in the INT_ENABLE register is asserted. 
 	
 	# Bits I2C_SLV4_NACK
-	# Asserted when slave 4 receives a NACK, will cause an interrupt if bit I2C_MST_INT_EN
+	# Asserted when subordinate 4 receives a NACK, will cause an interrupt if bit I2C_MST_INT_EN
 	#           in the INT_ENABLE register is asserted. 
 	
 	# Bits I2C_SLV3_NACK
-	# Asserted when slave 3 receives a NACK, will cause an interrupt if bit I2C_MST_INT_EN
+	# Asserted when subordinate 3 receives a NACK, will cause an interrupt if bit I2C_MST_INT_EN
 	#           in the INT_ENABLE register is asserted. 
 	
 	# Bits I2C_SLV2_NACK
-	# Asserted when slave 2 receives a NACK, will cause an interrupt if bit I2C_MST_INT_EN
+	# Asserted when subordinate 2 receives a NACK, will cause an interrupt if bit I2C_MST_INT_EN
 	#           in the INT_ENABLE register is asserted. 
 	
 	# Bits I2C_SLV1_NACK
-	# Asserted when slave 1 receives a NACK, will cause an interrupt if bit I2C_MST_INT_EN
+	# Asserted when subordinate 1 receives a NACK, will cause an interrupt if bit I2C_MST_INT_EN
 	#           in the INT_ENABLE register is asserted. 
 	
 	# Bits I2C_SLV0_NACK
-	# Asserted when slave 0 receives a NACK, will cause an interrupt if bit I2C_MST_INT_EN
+	# Asserted when subordinate 0 receives a NACK, will cause an interrupt if bit I2C_MST_INT_EN
 	#           in the INT_ENABLE register is asserted. 
 	
 	# Register INT_STATUS
@@ -356,7 +356,7 @@ class ICM_20948_Base:
 	# Bits DMP_INT1
 	# 1 - Indicates the DMP has generated INT1 interrupt. 
 	# Bits I2C_MST_INT
-	# 1 - Indicates I2C master has generated an interrupt. 
+	# 1 - Indicates I2C main has generated an interrupt. 
 	# Register INT_STATUS_1
 	# type USR0, bank 0 
 	
@@ -658,7 +658,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_00, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_00
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -674,7 +674,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_01, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_01
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -690,7 +690,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_02, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_02
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -706,7 +706,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_03, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_03
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -722,7 +722,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_04, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_04
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -738,7 +738,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_05, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_05
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -754,7 +754,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_06, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_06
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -770,7 +770,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_07, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_07
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -786,7 +786,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_08, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_08
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -802,7 +802,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_09, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_09
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -818,7 +818,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_10, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_10
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -834,7 +834,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_11, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_11
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -850,7 +850,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_12, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_12
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -866,7 +866,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_13, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_13
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -882,7 +882,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_14, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_14
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -898,7 +898,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_15, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_15
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -914,7 +914,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_16, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_16
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -930,7 +930,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_17, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_17
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -946,7 +946,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_18, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_18
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -962,7 +962,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_19, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_19
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -978,7 +978,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_20, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_20
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -994,7 +994,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_21, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_21
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -1010,7 +1010,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_22, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_22
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	
@@ -1026,7 +1026,7 @@ class ICM_20948_Base:
 		return self.read(REG.EXT_SLV_SENS_DATA_23, 8)
 	
 	# Bits EXT_SLV_SENS_DATA_23
-	# Sensor data read from external I2C devices via the I2C master interface. The data
+	# Sensor data read from external I2C devices via the I2C main interface. The data
 	#           stored is controlled by the I2C_SLV(0-4)_ADDR, I2C_SLV(0-4)_REG, and I2C_SLV(0-
 	#           4)_CTRL registers. 
 	

--- a/ICM-20948_3.py
+++ b/ICM-20948_3.py
@@ -56,18 +56,18 @@ class ICM_20948_Base:
 		return self.read(REG.I2C_MST_CTRL, 8)
 	
 	# Bits MULT_MST_EN
-	# Enables multi-master capability. When disabled, clocking to the I2C_MST_IF can be
+	# Enables multi-main capability. When disabled, clocking to the I2C_MST_IF can be
 	#           disabled when not in use and the logic to detect lost arbitration is disabled. 
 	
 	# Bits reserved_0
 	# Bits I2C_MST_P_NSR
-	# This bit controls the I2C Master’s transition from one slave read to the next slave
+	# This bit controls the I2C Main’s transition from one subordinate read to the next subordinate
 	#           read.
 	#           0 - There is a restart between reads.
 	#           1 - There is a stop between reads. 
 	
 	# Bits I2C_MST_CLK
-	# Sets I2C master clock frequency as shown in Table 23. 
+	# Sets I2C main clock frequency as shown in Table 23. 
 	# Register I2C_MST_DELAY_CTRL
 	# type USR3, bank 3 
 	
@@ -83,23 +83,23 @@ class ICM_20948_Base:
 	# Delays shadowing of external sensor data until all data is received. 
 	# Bits reserved_0
 	# Bits I2C_SLV4_DELAY_EN
-	# When enabled, slave 4 will only be accessed 1/(1+I2C_SLC4_DLY) samples as
+	# When enabled, subordinate 4 will only be accessed 1/(1+I2C_SLC4_DLY) samples as
 	#           determined by I2C_MST_ODR_CONFIG. 
 	
 	# Bits I2C_SLV3_DELAY_EN
-	# When enabled, slave 3 will only be accessed 1/(1+I2C_SLC4_DLY) samples as
+	# When enabled, subordinate 3 will only be accessed 1/(1+I2C_SLC4_DLY) samples as
 	#           determined by I2C_MST_ODR_CONFIG. 
 	
 	# Bits I2C_SLV2_DELAY_EN
-	# When enabled, slave 2 will only be accessed 1/(1+I2C_SLC4_DLY) samples as
+	# When enabled, subordinate 2 will only be accessed 1/(1+I2C_SLC4_DLY) samples as
 	#           determined by I2C_MST_ODR_CONFIG. 
 	
 	# Bits I2C_SLV1_DELAY_EN
-	# When enabled, slave 1 will only be accessed 1/(1+I2C_SLC4_DLY) samples as
+	# When enabled, subordinate 1 will only be accessed 1/(1+I2C_SLC4_DLY) samples as
 	#           determined by I2C_MST_ODR_CONFIG. 
 	
 	# Bits I2C_SLV0_DELAY_EN
-	# When enabled, slave 0 will only be accessed 1/(1+I2C_SLC4_DLY) samples as
+	# When enabled, subordinate 0 will only be accessed 1/(1+I2C_SLC4_DLY) samples as
 	#           determined by I2C_MST_ODR_CONFIG. 
 	
 	# Register I2C_SLV0_ADDR
@@ -118,7 +118,7 @@ class ICM_20948_Base:
 	#           0 - Transfer is a write. 
 	
 	# Bits I2C_ID_0
-	# Physical address of I2C slave 0. 
+	# Physical address of I2C subordinate 0. 
 	# Register I2C_SLV0_REG
 	# type USR3, bank 3 
 	
@@ -131,7 +131,7 @@ class ICM_20948_Base:
 		return self.read(REG.I2C_SLV0_REG, 8)
 	
 	# Bits I2C_SLV0_REG
-	# I2C slave 0 register address from where to begin data transfer. 
+	# I2C subordinate 0 register address from where to begin data transfer. 
 	# Register I2C_SLV0_CTRL
 	# type USR3, bank 3 
 	
@@ -144,9 +144,9 @@ class ICM_20948_Base:
 		return self.read(REG.I2C_SLV0_CTRL, 8)
 	
 	# Bits I2C_SLV0_EN
-	# 1 - Enable reading data from this slave at the sample rate and storing data at the first
-	#           available EXT_SENS_DATA register, which is always EXT_SENS_DATA_00 for I2C slave 0.
-	#           0 - Function is disabled for this slave. 
+	# 1 - Enable reading data from this subordinate at the sample rate and storing data at the first
+	#           available EXT_SENS_DATA register, which is always EXT_SENS_DATA_00 for I2C subordinate 0.
+	#           0 - Function is disabled for this subordinate. 
 	
 	# Bits I2C_SLV0_BYTE_SW
 	# 1 - Swap bytes when reading both the low and high byte of a word. Note there is
@@ -166,15 +166,15 @@ class ICM_20948_Base:
 	
 	# Bits I2C_SLV0_GRP
 	# External sensor data typically comes in as groups of two bytes. This bit is used to
-	#           determine if the groups are from the slave’s register address 0 and 1, 2 and 3, etc.., or if
+	#           determine if the groups are from the subordinate’s register address 0 and 1, 2 and 3, etc.., or if
 	#           the groups are address 1 and 2, 3 and 4, etc.
-	#           0 indicates slave register addresses 0 and 1 are grouped together (odd numbered
-	#           register ends the group). 1 indicates slave register addresses 1 and 2 are grouped
+	#           0 indicates subordinate register addresses 0 and 1 are grouped together (odd numbered
+	#           register ends the group). 1 indicates subordinate register addresses 1 and 2 are grouped
 	#           together (even numbered register ends the group). This allows byte swapping of
 	#           registers that are grouped starting at any address. 
 	
 	# Bits I2C_SLV0_LENG
-	# Number of bytes to be read from I2C slave 0. 
+	# Number of bytes to be read from I2C subordinate 0. 
 	# Register I2C_SLV0_DO
 	# type USR3, bank 3 
 	
@@ -187,7 +187,7 @@ class ICM_20948_Base:
 		return self.read(REG.I2C_SLV0_DO, 8)
 	
 	# Bits I2C_SLV0_DO
-	# Data out when slave 0 is set to write. 
+	# Data out when subordinate 0 is set to write. 
 	# Register I2C_SLV1_ADDR
 	# type USR3, bank 3 
 	
@@ -204,7 +204,7 @@ class ICM_20948_Base:
 	#           0 - Transfer is a write. 
 	
 	# Bits I2C_ID_1
-	# Physical address of I2C slave 1. 
+	# Physical address of I2C subordinate 1. 
 	# Register I2C_SLV1_REG
 	# type USR3, bank 3 
 	
@@ -217,7 +217,7 @@ class ICM_20948_Base:
 		return self.read(REG.I2C_SLV1_REG, 8)
 	
 	# Bits I2C_SLV1_REG
-	# I2C slave 1 register address from where to begin data transfer. 
+	# I2C subordinate 1 register address from where to begin data transfer. 
 	# Register I2C_SLV1_CTRL
 	# type USR3, bank 3 
 	
@@ -230,19 +230,19 @@ class ICM_20948_Base:
 		return self.read(REG.I2C_SLV1_CTRL, 8)
 	
 	# Bits I2C_SLV1_EN
-	# 1 - Enable reading data from this slave at the sample rate and storing data at the first
+	# 1 - Enable reading data from this subordinate at the sample rate and storing data at the first
 	#           available EXT_SENS_DATA register as determined by I2C_SLV0_EN and
 	#           I2C_SLV0_LENG.
-	#           0 - Function is disabled for this slave. 
+	#           0 - Function is disabled for this subordinate. 
 	
 	# Bits I2C_SLV1_BYTE_SW
 	# 1 - Swap bytes when reading both the low and high byte of a word. Note there is
 	#           nothing to swap after reading the first byte if I2C_SLV1_REG[0] = 1, or if the last byte
 	#           read has a register address lsb = 0.
 	#           For example, if I2C_SLV0_EN = 0x1, and I2C_SLV0_LENG = 0x3 (to show swap has to
-	#           do with I2C slave address not EXT_SENS_DATA address), and if I2C_SLV1_REG = 0x1,
+	#           do with I2C subordinate address not EXT_SENS_DATA address), and if I2C_SLV1_REG = 0x1,
 	#           and I2C_SLV1_LENG = 0x4:
-	#           1) The first byte read from address 0x1 will be stored at EXT_SENS_DATA_03 (slave
+	#           1) The first byte read from address 0x1 will be stored at EXT_SENS_DATA_03 (subordinate
 	#           0’s data will be in EXT_SENS_DATA_00, EXT_SENS_DATA_01, and
 	#           EXT_SENS_DATA_02),
 	#           2) the second and third bytes will be read and swapped, so the data read from
@@ -257,15 +257,15 @@ class ICM_20948_Base:
 	
 	# Bits I2C_SLV1_GRP
 	# External sensor data typically comes in as groups of two bytes. This bit is used to
-	#           determine if the groups are from the slave’s register address 0 and 1, 2 and 3, etc..,
+	#           determine if the groups are from the subordinate’s register address 0 and 1, 2 and 3, etc..,
 	#           or if the groups are address 1 and 2, 3 and 4, etc.
-	#           0 indicates slave register addresses 0 and 1 are grouped together (odd numbered
-	#           register ends the group). 1 indicates slave register addresses 1 and 2 are grouped
+	#           0 indicates subordinate register addresses 0 and 1 are grouped together (odd numbered
+	#           register ends the group). 1 indicates subordinate register addresses 1 and 2 are grouped
 	#           together (even numbered register ends the group). This allows byte swapping of
 	#           registers that are grouped starting at any address. 
 	
 	# Bits I2C_SLV1_LENG
-	# Number of bytes to be read from I2C slave 1. 
+	# Number of bytes to be read from I2C subordinate 1. 
 	# Register I2C_SLV1_DO
 	# type USR3, bank 3 
 	
@@ -278,7 +278,7 @@ class ICM_20948_Base:
 		return self.read(REG.I2C_SLV1_DO, 8)
 	
 	# Bits I2C_SLV1_DO
-	# Data out when slave 1 is set to write. 
+	# Data out when subordinate 1 is set to write. 
 	# Register I2C_SLV2_ADDR
 	# type USR3, bank 3 
 	
@@ -295,7 +295,7 @@ class ICM_20948_Base:
 	#           0 - Transfer is a write. 
 	
 	# Bits I2C_ID_2
-	# Physical address of I2C slave 2. 
+	# Physical address of I2C subordinate 2. 
 	# Register I2C_SLV2_REG
 	# type USR3, bank 3 
 	
@@ -308,7 +308,7 @@ class ICM_20948_Base:
 		return self.read(REG.I2C_SLV2_REG, 8)
 	
 	# Bits I2C_SLV2_REG
-	# I2C slave 2 register address from where to begin data transfer. 
+	# I2C subordinate 2 register address from where to begin data transfer. 
 	# Register I2C_SLV2_CTRL
 	# type USR3, bank 3 
 	
@@ -321,10 +321,10 @@ class ICM_20948_Base:
 		return self.read(REG.I2C_SLV2_CTRL, 8)
 	
 	# Bits I2C_SLV2_EN
-	# 1 - Enable reading data from this slave at the sample rate and storing data at the first
+	# 1 - Enable reading data from this subordinate at the sample rate and storing data at the first
 	#           available EXT_SENS_DATA register as determined by I2C_SLV0_EN, I2C_SLV0_LENG,
 	#           I2C_SLV1_EN and I2C_SLV1_LENG.
-	#           0 - Function is disabled for this slave. 
+	#           0 - Function is disabled for this subordinate. 
 	
 	# Bits I2C_SLV2_BYTE_SW
 	# 1 - Swap bytes when reading both the low and high byte of a word. Note there is
@@ -339,15 +339,15 @@ class ICM_20948_Base:
 	
 	# Bits I2C_SLV2_GRP
 	# External sensor data typically comes in as groups of two bytes. This bit is used to
-	#           determine if the groups are from the slave’s register address 0 and 1, 2 and 3, etc..,
+	#           determine if the groups are from the subordinate’s register address 0 and 1, 2 and 3, etc..,
 	#           or if the groups are address 1 and 2, 3 and 4, etc.
-	#           0 indicates slave register addresses 0 and 1 are grouped together (odd numbered
-	#           register ends the group). 1 indicates slave register addresses 1 and 2 are grouped
+	#           0 indicates subordinate register addresses 0 and 1 are grouped together (odd numbered
+	#           register ends the group). 1 indicates subordinate register addresses 1 and 2 are grouped
 	#           together (even numbered register ends the group). This allows byte swapping of
 	#           registers that are grouped starting at any address. 
 	
 	# Bits I2C_SLV2_LENG
-	# Number of bytes to be read from I2C slave 2. 
+	# Number of bytes to be read from I2C subordinate 2. 
 	# Register I2C_SLV2_DO
 	# type USR3, bank 3 
 	
@@ -360,7 +360,7 @@ class ICM_20948_Base:
 		return self.read(REG.I2C_SLV2_DO, 8)
 	
 	# Bits I2C_SLV2_DO
-	# Data out when slave 2 is set to write. 
+	# Data out when subordinate 2 is set to write. 
 	# Register I2C_SLV3_ADDR
 	# type USR3, bank 3 
 	
@@ -377,7 +377,7 @@ class ICM_20948_Base:
 	#           0 - Transfer is a write. 
 	
 	# Bits I2C_ID_3
-	# Physical address of I2C slave 3. 
+	# Physical address of I2C subordinate 3. 
 	# Register I2C_SLV3_REG
 	# type USR3, bank 3 
 	
@@ -390,7 +390,7 @@ class ICM_20948_Base:
 		return self.read(REG.I2C_SLV3_REG, 8)
 	
 	# Bits I2C_SLV3_REG
-	# I2C slave 3 register address from where to begin data transfer. 
+	# I2C subordinate 3 register address from where to begin data transfer. 
 	# Register I2C_SLV3_CTRL
 	# type USR3, bank 3 
 	
@@ -403,10 +403,10 @@ class ICM_20948_Base:
 		return self.read(REG.I2C_SLV3_CTRL, 8)
 	
 	# Bits I2C_SLV3_EN
-	# 1 - Enable reading data from this slave at the sample rate and storing data at the first
+	# 1 - Enable reading data from this subordinate at the sample rate and storing data at the first
 	#           available EXT_SENS_DATA register as determined by I2C_SLV0_EN, I2C_SLV0_LENG,
 	#           I2C_SLV1_EN, I2C_SLV1_LENG, I2C_SLV2_EN and I2C_SLV2_LENG.
-	#           0 - Function is disabled for this slave. 
+	#           0 - Function is disabled for this subordinate. 
 	
 	# Bits I2C_SLV3_BYTE_SW
 	# 1 - Swap bytes when reading both the low and high byte of a word.  Note there is
@@ -421,15 +421,15 @@ class ICM_20948_Base:
 	
 	# Bits I2C_SLV3_GRP
 	# External sensor data typically comes in as groups of two bytes. This bit is used to
-	#           determine if the groups are from the slave’s register address 0 and 1, 2 and 3, etc..,
+	#           determine if the groups are from the subordinate’s register address 0 and 1, 2 and 3, etc..,
 	#           or if the groups are address 1 and 2, 3 and 4, etc.
-	#           0 indicates slave register addresses 0 and 1 are grouped together (odd numbered
-	#           register ends the group). 1 indicates slave register addresses 1 and 2 are grouped
+	#           0 indicates subordinate register addresses 0 and 1 are grouped together (odd numbered
+	#           register ends the group). 1 indicates subordinate register addresses 1 and 2 are grouped
 	#           together (even numbered register ends the group). This allows byte swapping of
 	#           registers that are grouped starting at any address. 
 	
 	# Bits I2C_SLV3_LENG
-	# Number of bytes to be read from I2C slave 3. 
+	# Number of bytes to be read from I2C subordinate 3. 
 	# Register I2C_SLV3_DO
 	# type USR3, bank 3 
 	
@@ -442,10 +442,10 @@ class ICM_20948_Base:
 		return self.read(REG.I2C_SLV3_DO, 8)
 	
 	# Bits I2C_SLV3_DO
-	# Data out when slave 3 is set to write. 
+	# Data out when subordinate 3 is set to write. 
 	# Register I2C_SLV4_ADDR
 	# type USR3, bank 3 
-	# The I2C Slave 4 interface can be used to perform only single byte read and write transactions. 
+	# The I2C Subordinate 4 interface can be used to perform only single byte read and write transactions. 
 	
 	
 	def setI2C_SLV4_ADDR(self, val):
@@ -461,7 +461,7 @@ class ICM_20948_Base:
 	#           0 - Transfer is a write. 
 	
 	# Bits I2C_ID_4
-	# Physical address of I2C slave 4. 
+	# Physical address of I2C subordinate 4. 
 	# Register I2C_SLV4_REG
 	# type USR3, bank 3 
 	
@@ -474,7 +474,7 @@ class ICM_20948_Base:
 		return self.read(REG.I2C_SLV4_REG, 8)
 	
 	# Bits I2C_SLV4_REG
-	# I2C slave 4 register address from where to begin data transfer. 
+	# I2C subordinate 4 register address from where to begin data transfer. 
 	# Register I2C_SLV4_CTRL
 	# type USR3, bank 3 
 	
@@ -487,22 +487,22 @@ class ICM_20948_Base:
 		return self.read(REG.I2C_SLV4_CTRL, 8)
 	
 	# Bits I2C_SLV4_EN
-	# 1 - Enable data transfer with this slave at the sample rate. If read command, store
+	# 1 - Enable data transfer with this subordinate at the sample rate. If read command, store
 	#           data in I2C_SLV4_DI register, if write command, write data stored in I2C_SLV4_DO
 	#           register. Bit is cleared when a single transfer is complete. Be sure to write
 	#           I2C_SLV4_DO first.
-	#           0 - Function is disabled for this slave. 
+	#           0 - Function is disabled for this subordinate. 
 	
 	# Bits I2C_SLV4_INT_EN
-	# 1 - Enables the completion of the I2C slave 4 data transfer to cause an interrupt.
-	#           0 - Completion of the I2C slave 4 data transfer will not cause an interrupt. 
+	# 1 - Enables the completion of the I2C subordinate 4 data transfer to cause an interrupt.
+	#           0 - Completion of the I2C subordinate 4 data transfer will not cause an interrupt. 
 	
 	# Bits I2C_SLV4_REG_DIS
 	# When set, the transaction does not write a register value, it will only read data, or
 	#           write data. 
 	
 	# Bits I2C_SLV4_DLY
-	# When enabled via the I2C_MST_DELAY_CTRL, those slaves will only be enabled
+	# When enabled via the I2C_MST_DELAY_CTRL, those subordinates will only be enabled
 	#           every1/(1+I2C_SLV4_DLY) samples as determined by I2C_MST_ODR_CONFIG. 
 	
 	# Register I2C_SLV4_DO
@@ -517,7 +517,7 @@ class ICM_20948_Base:
 		return self.read(REG.I2C_SLV4_DO, 8)
 	
 	# Bits I2C_SLV4_DO
-	# Data out when slave 4 is set to write. 
+	# Data out when subordinate 4 is set to write. 
 	# Register I2C_SLV4_DI
 	# type USR3, bank 3 
 	
@@ -530,7 +530,7 @@ class ICM_20948_Base:
 		return self.read(REG.I2C_SLV4_DI, 8)
 	
 	# Bits I2C_SLV4_DI
-	# Data read from I2C Slave 4. 
+	# Data read from I2C Subordinate 4. 
 	# Register REG_BANK_SEL
 	# type , bank 3 
 	


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.